### PR TITLE
Certain Git repos don't even have the hooks directory so File.open fails.

### DIFF
--- a/lib/hookup.rb
+++ b/lib/hookup.rb
@@ -30,7 +30,12 @@ class Hookup
   def install
     dir = %x{git rev-parse --git-dir}.chomp
     raise Error, dir unless $?.success?
-    hook = File.join(dir, 'hooks', 'post-checkout')
+
+    hook_dir = File.join(dir, 'hooks')
+    Dir.mkdir(hook_dir, 0755) unless Dir.exists?(hook_dir)
+
+    hook = File.join(hook_dir, 'post-checkout')
+
     unless File.exist?(hook)
       File.open(hook, 'w', 0777) do |f|
         f.puts "#!/bin/bash"


### PR DESCRIPTION
Tested it on my machine and it fixed the problem.

Also extracted a couple methods for giggles.
