### PR TITLE
1.8.7 Dir Class Issue

### DIFF
--- a/lib/hookup.rb
+++ b/lib/hookup.rb
@@ -32,7 +32,7 @@ class Hookup
     raise Error, dir unless $?.success?
 
     hook_dir = File.join(dir, 'hooks')
-    Dir.mkdir(hook_dir, 0755) unless Dir.exists?(hook_dir)
+    Dir.mkdir(hook_dir, 0755) unless File.directory?(hook_dir)
 
     hook = File.join(hook_dir, 'post-checkout')
 


### PR DESCRIPTION
Didn't realize that `Dir.exist?` was a 1.9 method.  `File.directory?` should work for people still on 1.8.7 as well.
