### PR TITLE
Ensure down migrations work with GIT_WORK_TREE

### DIFF
--- a/lib/hookup.rb
+++ b/lib/hookup.rb
@@ -1,3 +1,5 @@
+require 'pathname'
+
 class Hookup
 
   class Error < RuntimeError
@@ -82,6 +84,14 @@ class Hookup
       env['HOOKUP_SCHEMA_DIR']
     end
 
+    def git_work_tree
+      unless @git_work_tree
+        @git_work_tree = %x{git rev-parse --show-toplevel}.chomp
+        raise Error, dir unless $?.success?
+      end
+      @git_work_tree
+    end
+
     def initialize(environment, *args)
       @env ||= environment.to_hash.dup
       require 'optparse'
@@ -148,6 +158,7 @@ class Hookup
       migrations = %x{git diff --name-status #{old} #{new} -- #{schema_dir}/migrate}.scan(/.+/).map {|l| l.split(/\t/) }
       begin
         migrations.select {|(t,f)| %w(D M).include?(t)}.reverse.each do |type, file|
+          file = Pathname.new(File.join(git_work_tree, file)).relative_path_from(Pathname.new(Dir.getwd)).to_s
           begin
             system 'git', 'checkout', old, '--', file
             unless rake 'db:migrate:down', "VERSION=#{File.basename(file)}"


### PR DESCRIPTION
**tl;dr:** this patch enables hooks to run with a `pwd` within, but deeper than the root of the containing git repo.

---

So I found this at the same time as the `GIT_DIR` thing, but it was seemingly unrelated hence a separate PR.

**The problem**
... started with changing the `pwd` inside the hook, such that it was no longer the repository root. In order for the git commands inside hookup to still work `GIT_WORK_TREE` had to be exported as the repository root.

The difficulty is that `git diff <sha1> -- migrations/*` returns output that's relative to the repository root, rather than `pwd`.

``` sh
~/repo/subdir$ git diff --name-status 53ddb9... beb5097... -- migrations/*
M       subdir/migrations/mig1.rb
```

When it comes time to checkout that future migration so it can be reverted, something like this happens:

``` sh
~/repo/subdir$ git co 53ddb9... -- subdir/migrations/mig1.rb
error: pathspec 'subdir/migrations/mig1.rb' did not match any file(s) known to git.
```

**The solution**
... is to join the repository root to the diff output to create an absolute path, and then convert that path relative to `pwd`

``` rb
absPath = File.join("/path/to/repo", "subdir/migrations/mig1.rb") #=> "/path/to/repo/subdir/migrations/mig1.rb"
path = Pathname.new(absPath).relative_path_from( ... pwd ... ) #=> "migrations/mig1.rb"
```

This new relative path can then be used to checkout the future migration and revert it.
