### PR TITLE
Fix error in case schema dir is not set

### DIFF
--- a/lib/hookup.rb
+++ b/lib/hookup.rb
@@ -111,7 +111,7 @@ class Hookup
       @new = args.shift || 'HEAD'
       @partial = (args.shift == '0')
 
-      env['HOOKUP_SCHEMA_DIR'] = 'db' unless schema_dir && File.directory?(schema_dir)
+      env['HOOKUP_SCHEMA_DIR'] = 'db' unless env['HOOKUP_SCHEMA_DIR'] && File.directory?(schema_dir)
     end
 
     def run


### PR DESCRIPTION
Since version 1.2.1 I have following error, because schema_dir raises exception when env['HOOKUP_SCHEMA_DIR'] is nil.

```
/Users/brainopia/.rvm/gems/ruby-1.9.3-p374@ohmystats/gems/hookup-1.2.1/lib/hookup.rb:82:in `expand_path': can't convert nil into String (TypeError)
    from /Users/brainopia/.rvm/gems/ruby-1.9.3-p374@ohmystats/gems/hookup-1.2.1/lib/hookup.rb:82:in `schema_dir'
    from /Users/brainopia/.rvm/gems/ruby-1.9.3-p374@ohmystats/gems/hookup-1.2.1/lib/hookup.rb:114:in `initialize'
    from /Users/brainopia/.rvm/gems/ruby-1.9.3-p374@ohmystats/gems/hookup-1.2.1/lib/hookup.rb:70:in `new'
    from /Users/brainopia/.rvm/gems/ruby-1.9.3-p374@ohmystats/gems/hookup-1.2.1/lib/hookup.rb:70:in `post_checkout'
    from /Users/brainopia/.rvm/gems/ruby-1.9.3-p374@ohmystats/gems/hookup-1.2.1/lib/hookup.rb:27:in `run'
    from /Users/brainopia/.rvm/gems/ruby-1.9.3-p374@ohmystats/gems/hookup-1.2.1/lib/hookup.rb:12:in `run'
    from /Users/brainopia/.rvm/gems/ruby-1.9.3-p374@ohmystats/gems/hookup-1.2.1/bin/hookup:4:in `<top (required)>'
    from /Users/brainopia/.rvm/gems/ruby-1.9.3-p374@ohmystats/bin/hookup:19:in `load'
    from /Users/brainopia/.rvm/gems/ruby-1.9.3-p374@ohmystats/bin/hookup:19:in `<main>'
    from /Users/brainopia/.rvm/gems/ruby-1.9.3-p374@ohmystats/bin/ruby_noexec_wrapper:14:in `eval'
    from /Users/brainopia/.rvm/gems/ruby-1.9.3-p374@ohmystats/bin/ruby_noexec_wrapper:14:in `<main>'
```
