### PR TITLE
Allow skipping post-checkout hook

### DIFF
--- a/lib/hookup.rb
+++ b/lib/hookup.rb
@@ -115,7 +115,7 @@ class Hookup
     end
 
     def run
-      return if env['GIT_REFLOG_ACTION'] =~ /^(?:pull|rebase)/
+      return if skipped? || env['GIT_REFLOG_ACTION'] =~ /^(?:pull|rebase)/
       unless partial?
         bundle
         migrate
@@ -200,6 +200,10 @@ class Hookup
           system 'rake', *args
         end
       end
+    end
+
+    def skipped?
+      env['SKIP_HOOKUP']
     end
 
   end


### PR DESCRIPTION
- If the SKIP_HOOKUP environment variable is set, skip the post-checkout
  command

@tpope you down?
