### PR TITLE
Parse Rails 5 schemas correctly

### DIFF
--- a/lib/hookup.rb
+++ b/lib/hookup.rb
@@ -259,7 +259,7 @@ class Hookup
 
   def resolve_schema_version(body, version)
     asd = "ActiveRecord::Schema.define"
-    body.sub!(/^<+ .*\n#{asd}\(#{version} (\d+)\) do\n=+\n#{asd}\(#{version} (\d+)\) do\n>+ .*/) do
+    body.sub!(/^<+ .*\n#{asd}\(#{version} ([0-9_]+)\) do\n=+\n#{asd}\(#{version} ([0-9_]+)\) do\n>+ .*/) do
       "#{asd}(#{version} #{[$1, $2].max}) do"
     end
   end


### PR DESCRIPTION
## Problem

[Latest versions of Rails](https://github.com/rails/rails/pull/28678) use a formatted number as schema versions:

```ruby
ActiveRecord::Schema.define(version: 2019_02_05_222329)
```

But the current substitution regex assumes only numbers, so the git merge driver doesn't work.

## Solution

Make the regex accept underscores.